### PR TITLE
表記ゆれ 修正前の[offence]で参照していたテストを[attack]に変更

### DIFF
--- a/spec/elements/thunder_spec.rb
+++ b/spec/elements/thunder_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../elements/thunder.rb"
 describe "Thunder" do
   let(:thunder) { Thunder.new }
   it "攻撃力が15上昇する" do
-    expect(thunder.offence).to eq(15)
+    expect(thunder.attack).to eq(15)
   end
   it "防御力は変わらない" do
     expect(thunder.defence).to eq(0)

--- a/spec/elements/water_spec.rb
+++ b/spec/elements/water_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../elements/water.rb"
 describe "Water" do
   let(:water) { Water.new }
   it "攻撃力が10上昇する" do
-    expect(water.offence).to eq(10)
+    expect(water.attack).to eq(10)
   end
   it "防御力が5上昇する" do
     expect(water.defence).to eq(5)

--- a/spec/elements/wind_spec.rb
+++ b/spec/elements/wind_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../elements/wind.rb"
 describe "Wind" do
   let(:wind) { Wind.new }
   it "攻撃力が５上昇する" do
-    expect(wind.offence).to eq(5)
+    expect(wind.attack).to eq(5)
   end
   it "防御力が10上昇する" do
     expect(wind.defence).to eq(10)

--- a/spec/equipments/glove_spec.rb
+++ b/spec/equipments/glove_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../equipments/glove.rb"
 describe "Glove" do
   let(:glove) { Glove.new }
   it "攻撃力が20上昇する" do
-    expect(glove.offence).to eq(20)
+    expect(glove.attack).to eq(20)
   end
   it "防御力が20上昇する" do
     expect(glove.defence).to eq(20)

--- a/spec/equipments/stick_spec.rb
+++ b/spec/equipments/stick_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../equipments/stick.rb"
 describe "Stick" do
   let(:stick) { Stick.new }
   it "攻撃力が30上昇する" do
-    expect(stick.offence).to eq(30)
+    expect(stick.attack).to eq(30)
   end
   it "防御力が10上昇する" do
     expect(stick.defence).to eq(10)

--- a/spec/equipments/sword_spec.rb
+++ b/spec/equipments/sword_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../equipments/sword.rb"
 describe "Sword" do
   let(:sword) { Sword.new }
   it "攻撃力が30上昇する" do
-    expect(sword.offence).to eq(30)
+    expect(sword.attack).to eq(30)
   end
   it "防御力が30上昇する" do
     expect(sword.defence).to eq(30)

--- a/spec/sexes/man_spec.rb
+++ b/spec/sexes/man_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../jobs/warrior"
 describe "Man" do
   let(:men) { Man.new }
   it "攻撃力が５上昇する" do
-    expect(men.offence).to eq(5)
+    expect(men.attack).to eq(5)
   end
   it "防御力は変わらない" do
     expect(men.defence).to eq(0)

--- a/spec/sexes/woman_spec.rb
+++ b/spec/sexes/woman_spec.rb
@@ -5,7 +5,7 @@ describe "Woman" do
   let(:women) { Woman.new }
 
   it "攻撃力は変わらない" do
-    expect(women.offence).to eq(0)
+    expect(women.attack).to eq(0)
   end
   it "防御力が５上昇する" do
     expect(women.defence).to eq(5)


### PR DESCRIPTION
## やったこと
- sexs、elements、equipmentsのテストで[offence]を使っていたところを[attack]に変更