### PR TITLE
.editorconfigでインデントの幅を間違えて指定していた

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-indent_size = 4
+indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true


### PR DESCRIPTION
## やったこと
- インデントが自動で４スペース分空いてしまっていたので、2スペース分に変更