### PR TITLE
キャラクターの強さ判定機能の呼び出し元を作成

### DIFF
--- a/guild.rb
+++ b/guild.rb
@@ -1,10 +1,23 @@
 require_relative 'job.rb'
 require_relative 'character_factory.rb'
+require_relative 'character_checker.rb'
 
 class Guild
   attr_reader :member
   def initialize
     @member = all_character
+  end
+
+  def best_characters
+    CharacterChecker.new(member).best_characters
+  end
+
+  def best_attackers
+    CharacterChecker.new(member).best_attackers
+  end
+
+  def best_defenders
+    CharacterChecker.new(member).best_defenders
   end
 
   private

--- a/spec/guild_spec.rb
+++ b/spec/guild_spec.rb
@@ -2,19 +2,75 @@ require_relative '../guild'
 
 describe Guild do
   let(:guild) { Guild.new }
-  it 'キャラクターの数は54人' do
-    expect(guild.member.count).to eq 54
+  describe 'キャラクターの数は54人' do
+    subject { guild.member.count }
+    it { is_expected.to eq 54 }
   end
-  it '1人目は剣を装備した風属性の男性武闘家' do
-    expect(guild.member.first.class).to eq Fighter
-    expect(guild.member.first).to have_attributes(sex: be_an_instance_of(Man))
-    expect(guild.member.first).to have_attributes(element: be_an_instance_of(Wind))
-    expect(guild.member.first).to have_attributes(equipment: be_an_instance_of(Sword))
+  describe '1人目は剣を装備した風属性の男性武闘家' do
+    subject { guild.member.first }
+    it { is_expected.to be_an_instance_of(Fighter) }
+    it { is_expected.to have_attributes(sex: be_an_instance_of(Man)) }
+    it { is_expected.to have_attributes(element: be_an_instance_of(Wind)) }
+    it { is_expected.to have_attributes(equipment: be_an_instance_of(Sword)) }
   end
-  it '54人目はグローブを装備した雷属性の女性魔法使い' do
-    expect(guild.member.last.class).to eq Wizard
-    expect(guild.member.last).to have_attributes(sex: be_an_instance_of(Woman))
-    expect(guild.member.last).to have_attributes(element: be_an_instance_of(Thunder))
-    expect(guild.member.last).to have_attributes(equipment: be_an_instance_of(Glove))
+  describe '54人目はグローブを装備した雷属性の女性魔法使い' do
+    subject { guild.member.last }
+    it { is_expected.to be_an_instance_of(Wizard) }
+    it { is_expected.to have_attributes(sex: be_an_instance_of(Woman)) }
+    it { is_expected.to have_attributes(element: be_an_instance_of(Thunder)) }
+    it { is_expected.to have_attributes(equipment: be_an_instance_of(Glove)) }
+  end
+  describe '#best_characters' do
+    describe 'キャラクターの数は2人' do
+      subject { guild.best_characters.count }
+      it { is_expected.to eq 2 }
+    end
+    describe '1人目は剣を装備した水属性の男性戦士' do
+      subject { guild.best_characters.first }
+      it { is_expected.to be_an_instance_of(Warrior) }
+      it { is_expected.to have_attributes(sex: be_an_instance_of(Man)) }
+      it { is_expected.to have_attributes(element: be_an_instance_of(Water)) }
+      it { is_expected.to have_attributes(equipment: be_an_instance_of(Sword)) }
+    end
+    describe '2人目は剣を装備した水属性の女性戦士' do
+      subject { guild.best_characters.last }
+      it { is_expected.to be_an_instance_of(Warrior) }
+      it { is_expected.to have_attributes(sex: be_an_instance_of(Woman)) }
+      it { is_expected.to have_attributes(element: be_an_instance_of(Water)) }
+      it { is_expected.to have_attributes(equipment: be_an_instance_of(Sword)) }
+    end
+  end
+  describe '#best_attackers' do
+    describe 'キャラクターの数は2人' do
+      subject { guild.best_attackers.count }
+      it { is_expected.to eq 2 }
+    end
+    describe '1人目は剣を装備した雷属性の男性戦士' do
+      subject { guild.best_attackers.first }
+      it { is_expected.to be_an_instance_of(Warrior) }
+      it { is_expected.to have_attributes(sex: be_an_instance_of(Man)) }
+      it { is_expected.to have_attributes(element: be_an_instance_of(Thunder)) }
+      it { is_expected.to have_attributes(equipment: be_an_instance_of(Sword)) }
+    end
+    describe '2人目は杖を装備した雷属性の男性魔法使い' do
+      subject { guild.best_attackers.last }
+      it { is_expected.to be_an_instance_of(Wizard) }
+      it { is_expected.to have_attributes(sex: be_an_instance_of(Man)) }
+      it { is_expected.to have_attributes(element: be_an_instance_of(Thunder)) }
+      it { is_expected.to have_attributes(equipment: be_an_instance_of(Stick)) }
+    end
+  end
+  describe '#best_defenders' do
+    describe 'キャラクターの数は1人' do
+      subject { guild.best_defenders.count }
+      it { is_expected.to eq 1 }
+    end
+    describe 'グローブを装備した風属性の女性武闘家' do
+      subject { guild.best_defenders.first }
+      it { is_expected.to be_an_instance_of(Fighter) }
+      it { is_expected.to have_attributes(sex: be_an_instance_of(Woman)) }
+      it { is_expected.to have_attributes(element: be_an_instance_of(Wind)) }
+      it { is_expected.to have_attributes(equipment: be_an_instance_of(Glove)) }
+    end
   end
 end


### PR DESCRIPTION
## やったこと
-キャラクターの強さを判定する機能の呼び出し元となるメソッドを `Guild` クラスに追加

### merge先について
- マージ先がmasterブランチでない理由
  - add_character_judgeとmasterの変更差分を取りこまないため。
- 最終的なマージ先
  - add_character_judgeがマージされた後、pull --rebaseで変更差分を取り込み、masterへとマージ

### pryデバッグの結果
- #best_charactersメソッド
[1] pry(RSpec::ExampleGroups::Guild)> Guild.new.best_characters
=> [#<Warrior:0x00007f98fd1ec880
  @element=#<Water:0x00007f98fd1ec948 @name="water">,
  @equipment=#<Sword:0x00007f98fd1ec8f8 @name="sword">,
  @sex=#<Man:0x00007f98fd1ec998 @name="man">>,
 #<Warrior:0x00007f98fd1f7c58
  @element=#<Water:0x00007f98fd1f7d20 @name="water">,
  @equipment=#<Sword:0x00007f98fd1f7cd0 @name="sword">,
  @sex=#<Woman:0x00007f98fd1f7d70 @name="woman">>]

- #best_attackersメソッド
[2] pry(RSpec::ExampleGroups::Guild)> Guild.new.best_attackers
=> [#<Warrior:0x00007f98fbbed138
  @element=#<Thunder:0x00007f98fbbed250 @name="thunder">,
  @equipment=#<Sword:0x00007f98fbbed1d8 @name="sword">,
  @sex=#<Man:0x00007f98fbbed2a0 @name="man">>,
 #<Wizard:0x00007f98fbbf4d48
  @element=#<Thunder:0x00007f98fbbf4e38 @name="thunder">,
  @equipment=#<Stick:0x00007f98fbbf4de8 @name="stick">,
  @sex=#<Man:0x00007f98fbbf4ed8 @name="man">>]

- #best_defendersメソッド
[3] pry(RSpec::ExampleGroups::Guild)> Guild.new.best_defenders
=> [#<Fighter:0x00007f98fc4c8208
  @element=#<Wind:0x00007f98fc4c82d0 @name="wind">,
  @equipment=#<Glove:0x00007f98fc4c8280 @name="glove">,
  @sex=#<Woman:0x00007f98fc4c8320 @name="woman">>]
