### PR TITLE
1行の長さが150字以内までならrubocopが落ちない様に変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 LineLength:
-  Max: 120
+  Max: 150
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
## やったこと
- 現状、記述の省略が難しい場所で rubocopが120字制限で落ちてしまう様になったので、上限を150字までに変更した