### PR TITLE
キャラの一覧作成のテストで文字列型で判定していた箇所をクラス型で判定する様に変更

### DIFF
--- a/spec/character_factory_spec.rb
+++ b/spec/character_factory_spec.rb
@@ -6,8 +6,8 @@ describe CharacterFactory do
       let(:fighters) { CharacterFactory.all_characters(Fighter) }
       it '武闘家が18人' do
         expect(fighters.count).to eq 18
-        expect(fighters.first.class.name).to eq 'Fighter'
-        expect(fighters.last.class.name).to eq 'Fighter'
+        expect(fighters.first.class).to eq Fighter
+        expect(fighters.last.class).to eq Fighter
       end
       it '1人目は剣を装備した風属性の男性武闘家' do
         expect(fighters.first).to have_attributes(sex: be_an_instance_of(Man))
@@ -24,8 +24,8 @@ describe CharacterFactory do
       let(:warriors) { CharacterFactory.all_characters(Warrior) }
       it '戦士が18人' do
         expect(warriors.count).to eq 18
-        expect(warriors.first.class.name).to eq 'Warrior'
-        expect(warriors.last.class.name).to eq 'Warrior'
+        expect(warriors.first.class).to eq Warrior
+        expect(warriors.last.class).to eq Warrior
       end
       it '1人目は剣を装備した風属性の男性戦士である' do
         expect(warriors.first).to have_attributes(sex: be_an_instance_of(Man))
@@ -42,8 +42,8 @@ describe CharacterFactory do
       let(:wizards) { CharacterFactory.all_characters(Wizard) }
       it '魔法使いが18人' do
         expect(wizards.count).to eq 18
-        expect(wizards.first.class.name).to eq 'Wizard'
-        expect(wizards.last.class.name).to eq 'Wizard'
+        expect(wizards.first.class).to eq Wizard
+        expect(wizards.last.class).to eq Wizard
       end
       it '1人目は剣を装備した風属性の男性魔法使いである' do
         expect(wizards.first).to have_attributes(sex: be_an_instance_of(Man))


### PR DESCRIPTION
## やったこと
- キャラクターの職業が任意のものかどうかを、文字列でなくクラスで判定する様に変更